### PR TITLE
Introduce chat states

### DIFF
--- a/ProjectA/ProjectA/Factory/IStateFactory.cs
+++ b/ProjectA/ProjectA/Factory/IStateFactory.cs
@@ -1,14 +1,10 @@
 ﻿using ProjectA.Models.StateOfChatModels.Enums;
 using ProjectA.States;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace ProjectA.Factory
 {
     public interface IStateFactory
     {
-        public  IState GetVehicle(StateTypes state);
+        IState GetState(StateType state);
     }
 }

--- a/ProjectA/ProjectA/Factory/StateFactory.cs
+++ b/ProjectA/ProjectA/Factory/StateFactory.cs
@@ -1,15 +1,37 @@
-﻿using ProjectA.Models.StateOfChatModels.Enums;
+﻿
+using ProjectA.Models.StateOfChatModels.Enums;
+using ProjectA.Services.PlayersSuggestion;
+using ProjectA.Services.StateProvider;
 using ProjectA.States;
-using System;
 
 namespace ProjectA.Factory
 {
     public class StateFactory : IStateFactory
     {
-        public IState GetVehicle(StateTypes state)
+        private readonly ICosmosDbStateProviderService stateProvider;
+        private readonly IPlayerSuggestionService players;
+
+        public StateFactory(ICosmosDbStateProviderService stateProvider, IPlayerSuggestionService players)
         {
-            throw new NotImplementedException();
-            // with a switch case the factory will return instance of a State classes we will create
+            this.stateProvider = stateProvider;
+            this.players = players;
         }
+
+        public IState GetState(StateType state)
+        {
+            var result = state switch
+            {
+                StateType.SuggestionsMenuState => new SuggestionsMenuState(stateProvider),
+                StateType.PlayersByOverallStatsState => new PlayersByOverallStatsState(stateProvider, players),
+                StateType.MainState or _ => (IState)new MainState(),
+            };
+
+            return result;
+        }
+        //public IState GetVehicle(StateTypes state)
+        //{
+        //    throw new NotImplementedException();
+        //    // with a switch case the factory will return instance of a State classes we will create
+        //}
     }
 }

--- a/ProjectA/ProjectA/Helpers/InteractionHelper.cs
+++ b/ProjectA/ProjectA/Helpers/InteractionHelper.cs
@@ -4,7 +4,7 @@ using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
-namespace ProjectA.Models
+namespace ProjectA.Helpers
 {
     public static class InteractionHelper
     {

--- a/ProjectA/ProjectA/Helpers/InteractionHelper.cs
+++ b/ProjectA/ProjectA/Helpers/InteractionHelper.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace ProjectA.Models
+{
+    public static class InteractionHelper
+    {
+        public static async Task<Message> SendInlineKeyboard(ITelegramBotClient botClient, long chatId, string prompt, InlineKeyboardMarkup options)
+        {
+            await botClient.SendChatActionAsync(chatId, ChatAction.Typing);
+
+            return await botClient.SendTextMessageAsync(chatId: chatId,
+                                                        text: prompt,
+                                                        replyMarkup: options);
+        }
+    }
+}

--- a/ProjectA/ProjectA/Models/PlayersModels/PlayerOverallStatsModel.cs
+++ b/ProjectA/ProjectA/Models/PlayersModels/PlayerOverallStatsModel.cs
@@ -1,4 +1,6 @@
-﻿namespace ProjectA.Models.PlayersModels
+﻿using System.Text;
+
+namespace ProjectA.Models.PlayersModels
 {
     public class PlayerOverallStatsModel
     {
@@ -13,5 +15,18 @@
         public double OverallStats { get; init; }
 
         public string Position { get; init; }
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+
+            sb
+                .AppendLine($"Name: {FirstName} {LastName}")
+                .AppendLine($"Price: {Price}")
+                .AppendLine($"Overall Stats: {OverallStats:f2}")
+                .AppendLine($"Position: {Position.ToUpper()}");
+
+            return sb.ToString();
+        }
     }
 }

--- a/ProjectA/ProjectA/Models/StateOfChatModels/ChatState.cs
+++ b/ProjectA/ProjectA/Models/StateOfChatModels/ChatState.cs
@@ -1,11 +1,19 @@
 ﻿using Newtonsoft.Json;
 using ProjectA.Models.StateOfChatModels.Enums;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace ProjectA.Models.StateOfChatModels
 {
     public class ChatState
     {
+        public ChatState(long chatId, StateType state = StateType.MainState)
+        {
+            Id = Guid.NewGuid().ToString();
+            Chat_Id = chatId;
+            Current_State = state;
+        }
+
         [JsonProperty("id")]
         public string Id { get; set; }
 
@@ -15,6 +23,6 @@ namespace ProjectA.Models.StateOfChatModels
 
         [Required]
         [JsonProperty("current_state")]
-        public StateTypes Current_State { get; set; }
+        public StateType Current_State { get; set; }
     }
 }

--- a/ProjectA/ProjectA/Models/StateOfChatModels/Enums/StateType.cs
+++ b/ProjectA/ProjectA/Models/StateOfChatModels/Enums/StateType.cs
@@ -1,0 +1,9 @@
+﻿namespace ProjectA.Models.StateOfChatModels.Enums
+{
+    public enum StateType
+    {
+        MainState,
+        SuggestionsMenuState,
+        PlayersByOverallStatsState
+    }
+}

--- a/ProjectA/ProjectA/Models/StateOfChatModels/Enums/StateTypes.cs
+++ b/ProjectA/ProjectA/Models/StateOfChatModels/Enums/StateTypes.cs
@@ -1,6 +1,0 @@
-﻿namespace ProjectA.Models.StateOfChatModels.Enums
-{
-    public enum StateTypes
-    {
-    }
-}

--- a/ProjectA/ProjectA/Startup.cs
+++ b/ProjectA/ProjectA/Startup.cs
@@ -17,6 +17,7 @@ using ProjectA.Services.Statistics;
 using ProjectA.Services.Handlers;
 using ProjectA.Services.StateProvider;
 using System.Threading.Tasks;
+using ProjectA.Factory;
 
 namespace ProjectA
 {
@@ -41,6 +42,7 @@ namespace ProjectA
             services.AddTransient<IPlayerSuggestionService, PlayerSuggestionService>();
             services.AddTransient<IStatisticsService, StatisticsService>();
             services.AddTransient<IHandlerTeamService, HandlerTeamService>();
+            services.AddTransient<IStateFactory, StateFactory>();
             
             services.AddSingleton<ITelegramUpdateHandler, TelegramHandler>();
             services.AddSingleton<ITelegramBotClient>(new TelegramBotClient(Configuration["TelegramBotToken"]));

--- a/ProjectA/ProjectA/States/IState.cs
+++ b/ProjectA/ProjectA/States/IState.cs
@@ -7,10 +7,10 @@ namespace ProjectA.States
 {
     public interface IState
     {
-        Task<StateTypes> BotOnMessageReceived(ITelegramBotClient botClient, Message message);
+        Task<StateType> BotOnMessageReceived(ITelegramBotClient botClient, Message message);
 
-        Task<StateTypes> BotOnCallBackQueryReceived(ITelegramBotClient botClient, CallbackQuery callbackQuery);
+        Task<StateType> BotOnCallBackQueryReceived(ITelegramBotClient botClient, CallbackQuery callbackQuery);
 
-        void BotSendMessage(ITelegramBotClient botClient, long chatId);
+        Task BotSendMessage(ITelegramBotClient botClient, long chatId);
     }
 }

--- a/ProjectA/ProjectA/States/MainState.cs
+++ b/ProjectA/ProjectA/States/MainState.cs
@@ -1,0 +1,49 @@
+﻿using ProjectA.Models.StateOfChatModels.Enums;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+
+namespace ProjectA.States
+{
+    public class MainState : IState
+    {
+        public async Task<StateType> BotOnMessageReceived(ITelegramBotClient botClient, Message message)
+        {
+            if (message.Type != MessageType.Text)
+            {
+                return StateType.MainState;
+            }
+
+            return message.Text switch
+            {
+                //TODO: Add players Statitics and Teams Statistics menue states
+                //TODO: Introduce StatesConstants class
+
+                "/PlayersSuggestion" => StateType.SuggestionsMenuState,
+                //"/PlayersStatistics" => StateType.GetSuggestion,
+                //"/TeamsStatistics" => StateType.GetSuggestion,
+                _ => await PrintMessage(botClient, message.Chat.Id, "Please choose on of the options", StateType.MainState)
+            };
+        }
+
+        public Task<StateType> BotOnCallBackQueryReceived(ITelegramBotClient botClient, CallbackQuery callbackQuery)
+            => Task.FromResult(StateType.MainState);
+
+        public async Task BotSendMessage(ITelegramBotClient botClient, long chatId)
+        {
+            //TODO: Introduce StatesConstants class
+            await botClient.SendTextMessageAsync(chatId, $"Please choose on of the options:\n" +
+                                                   $"/PlayersSuggestion\n" +
+                                                   $"/PlayersStatistics\n" +
+                                                   $"/TeamsStatistics");
+        }
+
+        private static async Task<StateType> PrintMessage(ITelegramBotClient botClient, long chatId, string message, StateType returnState)
+        {
+            await botClient.SendTextMessageAsync(chatId, message);
+
+            return returnState;
+        }
+    }
+}

--- a/ProjectA/ProjectA/States/PlayersByOverallStatsState.cs
+++ b/ProjectA/ProjectA/States/PlayersByOverallStatsState.cs
@@ -1,0 +1,94 @@
+﻿using ProjectA.Models.StateOfChatModels;
+using ProjectA.Models.StateOfChatModels.Enums;
+using ProjectA.Services.PlayersSuggestion;
+using ProjectA.Services.StateProvider;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+
+namespace ProjectA.States
+{
+    public class PlayersByOverallStatsState : IState
+    {
+        private readonly ICosmosDbStateProviderService _stateProvider;
+        private readonly IPlayerSuggestionService players;
+
+        public PlayersByOverallStatsState(
+            ICosmosDbStateProviderService stateProvider, 
+            IPlayerSuggestionService players)
+        {
+            _stateProvider = stateProvider;
+            this.players = players;
+        }
+
+        public async Task<StateType> BotOnMessageReceived(ITelegramBotClient botClient, Message message)
+        {
+            if (message.Text == null)
+            {
+                return await PrintMessage(botClient, message.Chat.Id, "Please insert your preferences");
+            }
+
+            var userInputParsed = ParseUserInput(message.Text);
+
+            if (userInputParsed.Length != 3 ||
+                !double.TryParse(userInputParsed[1], out double minPrice) ||
+                !double.TryParse(userInputParsed[2], out double maxPrice))
+            {
+                return await PrintMessage(botClient, message.Chat.Id, "Wrong preferences format");
+            }
+
+            var position = userInputParsed[0];
+
+            var chat = await _stateProvider.GetChatStateAsync(message.Chat.Id);
+
+            await _stateProvider.UpdateChatStateAsync(chat);
+            var suggestionResult = await GetSuggestionAsStringAsync(minPrice, maxPrice, position);
+
+            await PrintMessage(botClient, message.Chat.Id, suggestionResult);
+
+            return StateType.MainState;
+        }
+
+        private async Task<string> GetSuggestionAsStringAsync(double minPrice, double maxPrice, string position)
+        {
+            var suggestedPlayers = await this.players.GetByOverallStats(position, minPrice, maxPrice);
+
+            var sb = new StringBuilder();
+
+            foreach (var player in suggestedPlayers)
+            {
+                sb.AppendLine(player.ToString());
+            }
+
+            return sb.ToString();
+        }
+
+        public async Task<StateType> BotOnCallBackQueryReceived(ITelegramBotClient botClient, CallbackQuery callbackQuery)
+        {
+            await botClient.AnswerCallbackQueryAsync(callbackQueryId: callbackQuery.Id);
+
+            return StateType.PlayersByOverallStatsState;
+        }
+
+        public async Task BotSendMessage(ITelegramBotClient botClient, long chatId)
+        {
+            await botClient.SendTextMessageAsync(chatId, $"Please enter your preferences:\n(position/min Price/max Price)");
+        }
+
+        private static async Task<StateType> PrintMessage(ITelegramBotClient botClient, long chatId, string message)
+        {
+            await botClient.SendTextMessageAsync(chatId, message);
+
+            return StateType.PlayersByOverallStatsState;
+        }
+
+        private string[] ParseUserInput(string userInput) 
+            => userInput
+                .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                .ToArray();
+    }
+}

--- a/ProjectA/ProjectA/States/SuggestionsMenuState.cs
+++ b/ProjectA/ProjectA/States/SuggestionsMenuState.cs
@@ -1,4 +1,4 @@
-﻿using ProjectA.Models;
+﻿using ProjectA.Helpers;
 using ProjectA.Models.StateOfChatModels.Enums;
 using ProjectA.Services.StateProvider;
 using System.Threading.Tasks;

--- a/ProjectA/ProjectA/States/SuggestionsMenuState.cs
+++ b/ProjectA/ProjectA/States/SuggestionsMenuState.cs
@@ -1,0 +1,76 @@
+﻿using ProjectA.Models;
+using ProjectA.Models.StateOfChatModels.Enums;
+using ProjectA.Services.StateProvider;
+using System.Threading.Tasks;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace ProjectA.States
+{
+    public class SuggestionsMenuState : IState
+    {
+        private readonly ICosmosDbStateProviderService _stateProvider;
+
+        public SuggestionsMenuState(ICosmosDbStateProviderService stateProvider)
+        {
+            _stateProvider = stateProvider;
+        }
+
+        public Task<StateType> BotOnMessageReceived(ITelegramBotClient botClient, Message message)
+            => Task.FromResult(StateType.SuggestionsMenuState);
+
+        public async Task<StateType> BotOnCallBackQueryReceived(ITelegramBotClient botClient, CallbackQuery callbackQuery)
+        {
+            await botClient.AnswerCallbackQueryAsync(callbackQueryId: callbackQuery.Id);
+
+            return callbackQuery.Data switch
+            {
+                //TODO: Add states for each suggestions criteria - e.g. "Points per game" and etc.
+                //TODO: Introduce StatesConstants class
+
+                "Points Per Game" => StateType.SuggestionsMenuState,
+                "Current Form" => StateType.SuggestionsMenuState,
+                "ITC Rank" => StateType.SuggestionsMenuState,
+                "Points Per Price" => StateType.SuggestionsMenuState,
+                "Overall stats" => StateType.PlayersByOverallStatsState,
+                "Back" or _ => MoveBack(callbackQuery.Message.Chat.Id)
+            };
+        }
+
+        public async Task BotSendMessage(ITelegramBotClient botClient, long chatId)
+        {
+            //TODO: Introduce StatesConstants class
+            var options = new InlineKeyboardMarkup(new[]
+            {
+                new [] 
+                { 
+                    InlineKeyboardButton.WithCallbackData("Points Per Game", "Points Per Game"),
+                    InlineKeyboardButton.WithCallbackData("Current Form", "Current Form")
+                },
+                new [] 
+                { 
+                    InlineKeyboardButton.WithCallbackData("ITC Rank", "ITC Rank"), 
+                    InlineKeyboardButton.WithCallbackData("Points Per Price", "Points Per Price") 
+                },
+                new [] 
+                {
+                    InlineKeyboardButton.WithCallbackData("Overall stats", "Overall stats"),
+                    InlineKeyboardButton.WithCallbackData("Back", "Back") 
+                }
+            });
+
+            var message = "To get 5 suggested players, please choose a criteria:";
+
+            await InteractionHelper.SendInlineKeyboard(botClient, chatId, message, options);
+        }
+
+        private StateType MoveBack(long chatId)
+        {
+            var chat = _stateProvider.GetChatStateAsync(chatId).Result;
+            _stateProvider.UpdateChatStateAsync(chat);
+
+            return StateType.MainState;
+        }
+    }
+}

--- a/ProjectA/ProjectA/appsettings.json
+++ b/ProjectA/ProjectA/appsettings.json
@@ -1,18 +1,18 @@
 {
-  "FantasyPremierLeagueUrl": "https://fantasy.premierleague.com",
-  "TelegramBotToken": "Your bot token here",
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "FantasyPremierLeagueUrl": "https://fantasy.premierleague.com",
+    "TelegramBotToken": "1986055474:AAGRl5JEGBaZ4JtsXQuHNUqoSScjLxVPHo8",
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "CosmosDb": {
+        "Account": "https://localhost:8081",
+        "Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+        "DatabaseName": "FPLBotDbTest",
+        "ContainerName": "chats"
     }
-  },
-  "AllowedHosts": "*",
-  "CosmosDb": {
-    "Account": "",
-    "Key": "",
-    "DatabaseName": "",
-    "ContainerName": ""
-  }
 }

--- a/ProjectA/ProjectA/appsettings.json
+++ b/ProjectA/ProjectA/appsettings.json
@@ -1,6 +1,6 @@
 {
     "FantasyPremierLeagueUrl": "https://fantasy.premierleague.com",
-    "TelegramBotToken": "1986055474:AAGRl5JEGBaZ4JtsXQuHNUqoSScjLxVPHo8",
+    "TelegramBotToken": "",
     "Logging": {
         "LogLevel": {
             "Default": "Information",
@@ -10,9 +10,9 @@
     },
     "AllowedHosts": "*",
     "CosmosDb": {
-        "Account": "https://localhost:8081",
-        "Key": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-        "DatabaseName": "FPLBotDbTest",
-        "ContainerName": "chats"
+        "Account": "",
+        "Key": "",
+        "DatabaseName": "",
+        "ContainerName": ""
     }
 }


### PR DESCRIPTION
What's done up to this point:

 - [x] TelegramHandler refactored to work with the new `State` feature. All previous methods are left intact at least until the second demo
 - [x] Added three basic states, which simulate all possible user steps - choosing an option from main menu, choosing a sub-option, inserting/processing of user's input  and returning a result
 - [x] Changed the `StateTypes enum` name to `StateType`
 - [x] Added an option to create new `ChatState `object in the CosmosDb if the the user interacts with the bot for the first time